### PR TITLE
Replace Slippage check with whitelist

### DIFF
--- a/contracts/params/tests/tests/helpers/mock_env.rs
+++ b/contracts/params/tests/tests/helpers/mock_env.rs
@@ -588,7 +588,6 @@ impl MockEnvBuilder {
                     },
                     channel_id: "0".to_string(),
                     timeout_seconds: 900,
-                    slippage_tolerance: Decimal::percent(10),
                     whitelisted_distributors: vec![],
                 },
                 &[],

--- a/contracts/params/tests/tests/helpers/mock_env.rs
+++ b/contracts/params/tests/tests/helpers/mock_env.rs
@@ -589,6 +589,7 @@ impl MockEnvBuilder {
                     channel_id: "0".to_string(),
                     timeout_seconds: 900,
                     slippage_tolerance: Decimal::percent(10),
+                    whitelisted_distributors: vec![],
                 },
                 &[],
                 "rewards-collector",

--- a/contracts/perps/tests/tests/helpers/mock_env.rs
+++ b/contracts/perps/tests/tests/helpers/mock_env.rs
@@ -727,6 +727,7 @@ impl MockEnvBuilder {
                     channel_id: "".to_string(),
                     timeout_seconds: 1,
                     slippage_tolerance: Default::default(),
+                    whitelisted_distributors: vec![],
                 },
                 &[],
                 "mock-rewards-collector",

--- a/contracts/perps/tests/tests/helpers/mock_env.rs
+++ b/contracts/perps/tests/tests/helpers/mock_env.rs
@@ -726,7 +726,6 @@ impl MockEnvBuilder {
                     },
                     channel_id: "".to_string(),
                     timeout_seconds: 1,
-                    slippage_tolerance: Default::default(),
                     whitelisted_distributors: vec![],
                 },
                 &[],

--- a/contracts/rewards-collector/base/src/contract.rs
+++ b/contracts/rewards-collector/base/src/contract.rs
@@ -95,7 +95,7 @@ where
             } => self.withdraw_from_credit_manager(deps, account_id, actions),
             ExecuteMsg::DistributeRewards {
                 denom,
-            } => self.distribute_rewards(deps, &env, &denom),
+            } => self.distribute_rewards(deps, &env, &denom, info.sender),
             ExecuteMsg::SwapAsset {
                 denom,
                 amount,
@@ -162,6 +162,7 @@ where
             fee_collector_config,
             channel_id,
             timeout_seconds,
+            whitelist_actions,
         } = new_cfg;
 
         cfg.address_provider =
@@ -173,6 +174,30 @@ where
         cfg.fee_collector_config = fee_collector_config.unwrap_or(cfg.fee_collector_config);
         cfg.channel_id = channel_id.unwrap_or(cfg.channel_id);
         cfg.timeout_seconds = timeout_seconds.unwrap_or(cfg.timeout_seconds);
+        
+        // Process whitelist actions if provided
+        if let Some(actions) = whitelist_actions {
+            for action in actions {
+                match action {
+                    mars_types::rewards_collector::WhitelistAction::AddAddress { address } => {
+                        // Validate the address
+                        let validated_addr = deps.api.addr_validate(&address)?;
+                        
+                        // Only add if not already in the list
+                        if !cfg.whitelisted_distributors.contains(&validated_addr) {
+                            cfg.whitelisted_distributors.push(validated_addr);
+                        }
+                    },
+                    mars_types::rewards_collector::WhitelistAction::RemoveAddress { address } => {
+                        // Validate the address for consistency
+                        let validated_addr = deps.api.addr_validate(&address)?;
+                        
+                        // Remove the address if it exists in the list
+                        cfg.whitelisted_distributors.retain(|addr| addr != &validated_addr);
+                    },
+                }
+            }
+        }
 
         cfg.validate()?;
 
@@ -392,12 +417,23 @@ where
         deps: DepsMut,
         env: &Env,
         denom: &str,
+        sender: Addr,
     ) -> ContractResult<Response<M>> {
         let mut res = Response::new().add_attribute("action", "distribute_rewards");
         let mut msgs: Vec<CosmosMsg<M>> = vec![];
 
         // Configs
         let cfg = &self.config.load(deps.storage)?;
+        
+        // Check if sender is allowed to distribute rewards
+        if !cfg.whitelisted_distributors.is_empty() && !cfg.whitelisted_distributors.contains(&sender) {
+            // Owner can always distribute rewards
+            if !self.owner.is_owner(deps.storage, &sender)? {
+                return Err(ContractError::UnauthorizedDistributor {
+                    sender: sender.to_string(),
+                });
+            }
+        }
         let safety_fund_config = &cfg.safety_fund_config;
         let revenue_share_config = &cfg.revenue_share_config;
         let fee_collector_config = &cfg.fee_collector_config;
@@ -515,6 +551,7 @@ where
             fee_collector_config: cfg.fee_collector_config,
             channel_id: cfg.channel_id,
             timeout_seconds: cfg.timeout_seconds,
+            whitelisted_distributors: cfg.whitelisted_distributors.iter().map(|addr| addr.to_string()).collect(),
         })
     }
 }

--- a/contracts/rewards-collector/base/src/contract.rs
+++ b/contracts/rewards-collector/base/src/contract.rs
@@ -8,7 +8,6 @@ use mars_types::{
     address_provider::{self, AddressResponseItem, MarsAddressType},
     credit_manager::{self, Action},
     incentives::{self, IncentiveKind},
-    oracle::ActionKind,
     red_bank,
     rewards_collector::{
         Config, ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, UpdateConfig,
@@ -163,7 +162,6 @@ where
             fee_collector_config,
             channel_id,
             timeout_seconds,
-            slippage_tolerance,
         } = new_cfg;
 
         cfg.address_provider =
@@ -175,7 +173,6 @@ where
         cfg.fee_collector_config = fee_collector_config.unwrap_or(cfg.fee_collector_config);
         cfg.channel_id = channel_id.unwrap_or(cfg.channel_id);
         cfg.timeout_seconds = timeout_seconds.unwrap_or(cfg.timeout_seconds);
-        cfg.slippage_tolerance = slippage_tolerance.unwrap_or(cfg.slippage_tolerance);
 
         cfg.validate()?;
 
@@ -321,42 +318,22 @@ where
         )?;
 
         let swapper_addr = &addresses[0].address;
-        let oracle_addr = &addresses[1].address;
-
-        let asset_in_price = deps
-            .querier
-            .query_wasm_smart::<mars_types::oracle::PriceResponse>(
-                oracle_addr.to_string(),
-                &mars_types::oracle::QueryMsg::Price {
-                    denom: denom.to_string(),
-                    kind: Some(ActionKind::Default),
-                },
-            )?
-            .price;
-
-        // apply slippage to asset in price. Creating this variable means we only need to apply
-        // slippage tolerance calculation once, instead of for each denom
-        let slippage_adjusted_asset_in_price =
-            asset_in_price.checked_mul(Decimal::one().checked_sub(cfg.slippage_tolerance)?)?;
 
         // execute the swap to safety fund denom, if the amount to swap is non-zero,
         // and if the denom is not already the safety fund denom
         // Note that revenue share is included in this swap as they are the same denom
         if !rf_and_sf_combined.is_zero() && denom != cfg.safety_fund_config.target_denom {
-            let swap_msg = self.swap_asset_to_reward(
-                &deps,
-                oracle_addr,
-                &denom.to_string(),
+            let swap_msg = self.generate_swap_msg(
+                swapper_addr,
+                denom,
                 rf_and_sf_combined,
-                slippage_adjusted_asset_in_price,
+                &cfg.safety_fund_config.target_denom,
                 safety_fund_min_receive.ok_or(
                     ContractError::InvalidMinReceive {
                         reason: "required to pass 'safety_fund_min_receive' when swapping safety fund amount".to_string()
                     }
                 )?,
-                &cfg.safety_fund_config.target_denom,
                 safety_fund_route,
-                swapper_addr,
             )?;
 
             messages.push(swap_msg);
@@ -365,20 +342,17 @@ where
         // execute the swap to fee collector denom, if the amount to swap is non-zero,
         // and if the denom is not already the fee collector denom
         if !fc_amount.is_zero() && denom != cfg.fee_collector_config.target_denom {
-            let swap_msg = self.swap_asset_to_reward(
-                &deps,
-                oracle_addr,
-                &denom.to_string(),
+            let swap_msg = self.generate_swap_msg(
+                swapper_addr,
+                denom,
                 fc_amount,
-                slippage_adjusted_asset_in_price,
+                &cfg.fee_collector_config.target_denom,
                 fee_collector_min_receive.ok_or(
                     ContractError::InvalidMinReceive {
                         reason: "required to pass 'fee_collector_min_receive' when swapping to fee collector".to_string()
                     }
                 )?,
-                &cfg.fee_collector_config.target_denom,
                 fee_collector_route,
-                swapper_addr,
             )?;
 
             messages.push(swap_msg);
@@ -390,48 +364,6 @@ where
             .add_attribute("denom", denom)
             .add_attribute("amount_safety_fund", rf_and_sf_combined)
             .add_attribute("amount_fee_collector", fc_amount))
-    }
-
-    fn swap_asset_to_reward(
-        &self,
-        deps: &DepsMut,
-        oracle_addr: &str,
-        asset_in_denom: &String,
-        asset_in_amount: Uint128,
-        slippage_adjusted_asset_in_price: Decimal,
-        min_receive: Uint128,
-        target_reward_denom: &String,
-        target_route: Option<SwapperRoute>,
-        swapper_addr: &str,
-    ) -> Result<WasmMsg, ContractError> {
-        let target_fund_price = deps
-            .querier
-            .query_wasm_smart::<mars_types::oracle::PriceResponse>(
-                oracle_addr.to_string(),
-                &mars_types::oracle::QueryMsg::Price {
-                    denom: target_reward_denom.to_string(),
-                    kind: Some(ActionKind::Default),
-                },
-            )?
-            .price;
-
-        self.ensure_min_receive_within_slippage_tolerance(
-            asset_in_denom.to_string(),
-            target_reward_denom.to_string(),
-            asset_in_amount,
-            slippage_adjusted_asset_in_price,
-            target_fund_price,
-            min_receive,
-        )?;
-
-        self.generate_swap_msg(
-            swapper_addr,
-            asset_in_denom,
-            asset_in_amount,
-            target_reward_denom,
-            min_receive,
-            target_route,
-        )
     }
 
     fn generate_swap_msg(
@@ -453,39 +385,6 @@ where
             })?,
             funds: vec![coin(amount_in.u128(), denom_in)],
         })
-    }
-
-    /// Ensure the slippage is not greater than what is tolerated in contract config
-    /// We do this by calculating the minimum_price and applying that to the min receive
-    /// Calculation is as follows:
-    /// Safety_denom price in oracle is 2
-    /// slippage_adjusted_asset_in_price (calculated via oracle) is 9.5
-    /// pair price = 9.5 / 2 = 4.75
-    /// minimum_tolerated = 4.75 * amount_in
-    fn ensure_min_receive_within_slippage_tolerance(
-        &self,
-        asset_in_denom: String,
-        asset_out_denom: String,
-        amount_in: Uint128,
-        slippage_adjusted_asset_in_price: Decimal,
-        asset_out_price: Decimal,
-        min_receive: Uint128,
-    ) -> Result<(), ContractError> {
-        // The price of the asset to be swapped, denominated in the output asset denom
-        let asset_out_denominated_price =
-            slippage_adjusted_asset_in_price.checked_div(asset_out_price)?;
-        let min_receive_lower_limit = amount_in.checked_mul_floor(asset_out_denominated_price)?;
-
-        if min_receive_lower_limit > min_receive {
-            return Err(ContractError::SlippageLimitExceeded {
-                denom_in: asset_in_denom,
-                denom_out: asset_out_denom,
-                min_receive_minumum: min_receive_lower_limit,
-                min_receive_given: min_receive,
-            });
-        }
-
-        Ok(())
     }
 
     pub fn distribute_rewards(
@@ -616,7 +515,6 @@ where
             fee_collector_config: cfg.fee_collector_config,
             channel_id: cfg.channel_id,
             timeout_seconds: cfg.timeout_seconds,
-            slippage_tolerance: cfg.slippage_tolerance,
         })
     }
 }

--- a/contracts/rewards-collector/base/src/error.rs
+++ b/contracts/rewards-collector/base/src/error.rs
@@ -72,6 +72,11 @@ pub enum ContractError {
     UnsupportedTransferType {
         transfer_type: String,
     },
+
+    #[error("Unauthorized: sender {sender} is not allowed to distribute rewards")]
+    UnauthorizedDistributor {
+        sender: String,
+    },
 }
 
 pub type ContractResult<T> = Result<T, ContractError>;

--- a/contracts/rewards-collector/base/src/helpers.rs
+++ b/contracts/rewards-collector/base/src/helpers.rs
@@ -38,7 +38,7 @@ pub(crate) fn ensure_distributor_whitelisted(
         return Ok(());
     }
 
-    if !cfg.whitelisted_distributors.is_empty() && !cfg.whitelisted_distributors.contains(sender) {
+    if cfg.whitelisted_distributors.is_empty() || !cfg.whitelisted_distributors.contains(sender) {
         return Err(ContractError::UnauthorizedDistributor {
             sender: sender.to_string(),
         });

--- a/contracts/rewards-collector/base/src/helpers.rs
+++ b/contracts/rewards-collector/base/src/helpers.rs
@@ -33,14 +33,17 @@ pub(crate) fn ensure_distributor_whitelisted(
     owner: &Owner,
     sender: &Addr,
 ) -> ContractResult<()> {
-    if !cfg.whitelisted_distributors.is_empty() && !cfg.whitelisted_distributors.contains(sender) {
-        // Owner can always distribute rewards
-        if !owner.is_owner(deps.storage, sender)? {
-            return Err(ContractError::UnauthorizedDistributor {
-                sender: sender.to_string(),
-            });
-        }
+    // Owner can always distribute rewards
+    if owner.is_owner(deps.storage, sender)? {
+        return Ok(());
     }
+
+    if !cfg.whitelisted_distributors.is_empty() && !cfg.whitelisted_distributors.contains(sender) {
+        return Err(ContractError::UnauthorizedDistributor {
+            sender: sender.to_string(),
+        });
+    }
+
     Ok(())
 }
 

--- a/contracts/rewards-collector/base/src/helpers.rs
+++ b/contracts/rewards-collector/base/src/helpers.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{Addr, QuerierWrapper, Uint128};
+use cosmwasm_std::{Addr, Deps, QuerierWrapper, Uint128};
+use mars_owner::Owner;
+use mars_types::rewards_collector::Config;
 
 use crate::{ContractError, ContractResult};
 
@@ -23,6 +25,23 @@ pub(crate) fn unwrap_option_amount(
     } else {
         Ok(balance)
     }
+}
+
+pub(crate) fn ensure_distributor_whitelisted(
+    deps: Deps,
+    cfg: &Config,
+    owner: &Owner,
+    sender: &Addr,
+) -> ContractResult<()> {
+    if !cfg.whitelisted_distributors.is_empty() && !cfg.whitelisted_distributors.contains(sender) {
+        // Owner can always distribute rewards
+        if !owner.is_owner(deps.storage, sender)? {
+            return Err(ContractError::UnauthorizedDistributor {
+                sender: sender.to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Convert an optional Uint128 amount to string. If the amount is undefined, return `undefined`

--- a/contracts/rewards-collector/neutron/src/migrations/v2_2_2.rs
+++ b/contracts/rewards-collector/neutron/src/migrations/v2_2_2.rs
@@ -56,7 +56,6 @@ pub fn migrate(deps: DepsMut) -> Result<Response, ContractError> {
     let new_config = Config {
         // old, unchanged values
         address_provider: existing_config.address_provider,
-        slippage_tolerance: existing_config.slippage_tolerance,
         timeout_seconds: existing_config.timeout_seconds,
 
         // set as empty so any ibc transfers error. This prevents mistakenly sending funds somewhere

--- a/contracts/rewards-collector/neutron/src/migrations/v2_2_2.rs
+++ b/contracts/rewards-collector/neutron/src/migrations/v2_2_2.rs
@@ -83,6 +83,9 @@ pub fn migrate(deps: DepsMut) -> Result<Response, ContractError> {
             target_denom: existing_config.fee_collector_denom,
             transfer_type: TransferType::Bank,
         },
+
+        // set to empty list
+        whitelisted_distributors: vec![],
     };
 
     // ensure our new config is legal

--- a/contracts/rewards-collector/osmosis/src/migrations/v2_1_1.rs
+++ b/contracts/rewards-collector/osmosis/src/migrations/v2_1_1.rs
@@ -89,6 +89,8 @@ pub fn migrate(deps: DepsMut) -> Result<Response, ContractError> {
             target_denom: old_config.fee_collector_denom,
             transfer_type: TransferType::Ibc,
         },
+        // empty initially
+        whitelisted_distributors: vec![],
     };
 
     // ensure our new config is legal

--- a/contracts/rewards-collector/osmosis/src/migrations/v2_1_1.rs
+++ b/contracts/rewards-collector/osmosis/src/migrations/v2_1_1.rs
@@ -59,7 +59,6 @@ pub fn migrate(deps: DepsMut) -> Result<Response, ContractError> {
     let new_config = Config {
         // old, unchanged values
         address_provider: old_config.address_provider,
-        slippage_tolerance: old_config.slippage_tolerance,
         timeout_seconds: old_config.timeout_seconds,
 
         // source channel on osmosis-1 for neutron-1 is channel-874. Proof below

--- a/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
@@ -32,6 +32,7 @@ pub fn mock_instantiate_msg() -> InstantiateMsg {
         channel_id: "channel-69".to_string(),
         timeout_seconds: 300,
         slippage_tolerance: Decimal::percent(3),
+        whitelisted_distributors: vec!["owner".to_string()],
     }
 }
 

--- a/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/helpers/mod.rs
@@ -31,8 +31,7 @@ pub fn mock_instantiate_msg() -> InstantiateMsg {
         },
         channel_id: "channel-69".to_string(),
         timeout_seconds: 300,
-        slippage_tolerance: Decimal::percent(3),
-        whitelisted_distributors: vec!["owner".to_string()],
+        whitelisted_distributors: vec!["owner".to_string(), "jake".to_string()],
     }
 }
 

--- a/contracts/rewards-collector/osmosis/tests/tests/mod.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/mod.rs
@@ -6,4 +6,5 @@ mod test_migration_v2;
 mod test_migration_v2_1_0_to_v2_1_1;
 mod test_swap;
 mod test_update_owner;
+mod test_whitelist_distributors;
 mod test_withdraw;

--- a/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
@@ -33,6 +33,7 @@ fn instantiating() {
             fee_collector_config: config.fee_collector_config,
             channel_id: config.channel_id,
             timeout_seconds: config.timeout_seconds,
+            whitelisted_distributors: vec!["owner".to_string()],
         }
     );
 

--- a/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
@@ -33,7 +33,6 @@ fn instantiating() {
             fee_collector_config: config.fee_collector_config,
             channel_id: config.channel_id,
             timeout_seconds: config.timeout_seconds,
-            slippage_tolerance: config.slippage_tolerance,
         }
     );
 
@@ -48,30 +47,6 @@ fn instantiating() {
             param_name: "total_tax_rate".to_string(),
             invalid_value: "1.6".to_string(),
             predicate: "<= 1".to_string(),
-        })
-    );
-}
-
-#[test]
-fn updating_config_if_invalid_slippage() {
-    let mut deps = helpers::setup_test();
-
-    let invalid_cfg = UpdateConfig {
-        slippage_tolerance: Some(Decimal::percent(51u64)),
-        ..Default::default()
-    };
-
-    let info = mock_info("owner");
-    let msg = ExecuteMsg::UpdateConfig {
-        new_cfg: invalid_cfg,
-    };
-    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::Validation(ValidationError::InvalidParam {
-            param_name: "slippage_tolerance".to_string(),
-            invalid_value: "0.51".to_string(),
-            predicate: "<= 0.5".to_string(),
         })
     );
 }

--- a/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_admin.rs
@@ -33,7 +33,7 @@ fn instantiating() {
             fee_collector_config: config.fee_collector_config,
             channel_id: config.channel_id,
             timeout_seconds: config.timeout_seconds,
-            whitelisted_distributors: vec!["owner".to_string()],
+            whitelisted_distributors: vec!["owner".to_string(), "jake".to_string()],
         }
     );
 

--- a/contracts/rewards-collector/osmosis/tests/tests/test_distribute_rewards.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_distribute_rewards.rs
@@ -106,7 +106,7 @@ fn assert_rewards_distribution(
     let res = execute(
         deps.as_mut(),
         env.clone(),
-        mock_info("jake"),
+        mock_info("owner"),
         ExecuteMsg::DistributeRewards {
             denom: denom_to_distribute,
         },

--- a/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_swap.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::{
     coin, testing::mock_env, to_json_binary, CosmosMsg, Decimal, Empty, SubMsg, Uint128, WasmMsg,
 };
-use mars_rewards_collector_base::ContractError;
 use mars_rewards_collector_osmosis::entry::execute;
 use mars_testing::mock_info;
 use mars_types::{
@@ -194,108 +193,4 @@ fn skipping_swap_if_denom_matches() {
     }
     .into();
     assert_eq!(res.messages[0], SubMsg::new(swap_msg));
-}
-
-#[test]
-fn swap_fails_if_slippage_limit_exceeded() {
-    let mut deps = helpers::setup_test();
-
-    let usdc_denom = "uusdc".to_string();
-    let mars_denom = "umars".to_string();
-    let atom_denom = "uatom".to_string();
-
-    let uusdc_usd_price = Decimal::one();
-    let umars_uusdc_price = Decimal::from_ratio(5u128, 10u128); // 0.5 uusdc = 1 umars
-    let uatom_uusdc_price = Decimal::from_ratio(125u128, 10u128); // 12.5 uusd = 1 uatom
-
-    deps.querier.set_oracle_price(&usdc_denom, uusdc_usd_price);
-
-    deps.querier.set_oracle_price(&mars_denom, umars_uusdc_price);
-
-    deps.querier.set_oracle_price(&atom_denom, uatom_uusdc_price);
-
-    deps.querier.set_swapper_estimate_price(&mars_denom, umars_uusdc_price);
-    deps.querier.set_swapper_estimate_price(&atom_denom, uatom_uusdc_price);
-    deps.querier.set_swapper_estimate_price(&usdc_denom, uusdc_usd_price);
-
-    // Here we test the slippage limits for each of the target reward denoms
-    //
-    // uatom for revenue share = 88888 * 0.1 = 8888
-    // uatom for safety fund = 88888 * 0.25 = 22222
-    // uatom for Fee collector = 88888 - 8888 - 22222 = 57778
-    // worst price (atom -> mars ) = 12.5 / 0/5 = 25 * (1-0.03) = 24.25
-    // worst price (atom -> usdc) = 12.5 = * (1-0.03) = 12.125
-    // minumum revenue share (atom -> usdc) = 8888 * 12.125 = 107767
-    // minumum safety fund (atom -> usdc) = 31110 * 12.125 = 377208
-    // minumum fee collector (atom -> mars) = 57778 * 24.25= 1401116
-
-    // Safety Fund fail
-    let res = execute(
-        deps.as_mut(),
-        mock_env(),
-        mock_info("jake"),
-        ExecuteMsg::SwapAsset {
-            denom: atom_denom.to_string(),
-            amount: None,
-            safety_fund_route: Some(SwapperRoute::Osmo(OsmoRoute {
-                swaps: vec![OsmoSwap {
-                    pool_id: 12,
-                    to: usdc_denom.to_string(),
-                }],
-            })),
-            fee_collector_route: Some(SwapperRoute::Osmo(OsmoRoute {
-                swaps: vec![OsmoSwap {
-                    pool_id: 69,
-                    to: mars_denom.to_string(),
-                }],
-            })),
-            safety_fund_min_receive: Some(Uint128::new(377207)), // 377207 < 377208 -> error
-            fee_collector_min_receive: Some(Uint128::new(1401116)), // pass
-        },
-    );
-
-    assert_eq!(
-        res.unwrap_err(),
-        ContractError::SlippageLimitExceeded {
-            denom_in: atom_denom.clone(),
-            denom_out: usdc_denom.clone(),
-            min_receive_minumum: Uint128::new(377208),
-            min_receive_given: Uint128::new(377207),
-        }
-    );
-
-    // Fee Collector fail
-    let res = execute(
-        deps.as_mut(),
-        mock_env(),
-        mock_info("jake"),
-        ExecuteMsg::SwapAsset {
-            denom: atom_denom.to_string(),
-            amount: None,
-            safety_fund_route: Some(SwapperRoute::Osmo(OsmoRoute {
-                swaps: vec![OsmoSwap {
-                    pool_id: 12,
-                    to: usdc_denom.to_string(),
-                }],
-            })),
-            fee_collector_route: Some(SwapperRoute::Osmo(OsmoRoute {
-                swaps: vec![OsmoSwap {
-                    pool_id: 69,
-                    to: mars_denom.to_string(),
-                }],
-            })),
-            safety_fund_min_receive: Some(Uint128::new(377208)), // pass
-            fee_collector_min_receive: Some(Uint128::new(1401115)), // 1401115 < 1401116 -> error
-        },
-    );
-
-    assert_eq!(
-        res.unwrap_err(),
-        ContractError::SlippageLimitExceeded {
-            denom_in: atom_denom.clone(),
-            denom_out: mars_denom.clone(),
-            min_receive_minumum: Uint128::new(1401116),
-            min_receive_given: Uint128::new(1401115),
-        }
-    );
 }

--- a/contracts/rewards-collector/osmosis/tests/tests/test_whitelist_distributors.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_whitelist_distributors.rs
@@ -1,0 +1,158 @@
+use cosmwasm_std::{testing::mock_env, Addr};
+use mars_owner::OwnerError::NotOwner;
+use mars_rewards_collector_base::{error::ContractError, ContractResult};
+use mars_rewards_collector_osmosis::entry::{execute, query};
+use mars_testing::mock_info;
+use mars_types::rewards_collector::{
+    ConfigResponse, ExecuteMsg, QueryMsg, UpdateConfig, WhitelistAction,
+};
+
+use super::helpers;
+
+#[test]
+fn whitelist_add_and_remove_distributor() {
+    let mut deps = helpers::setup_test();
+
+    // Initial state should have only the owner whitelisted
+    let cfg: ConfigResponse = helpers::query(deps.as_ref(), QueryMsg::Config {});
+    assert_eq!(cfg.whitelisted_distributors.len(), 1);
+    assert_eq!(cfg.whitelisted_distributors[0], "owner");
+
+    // Non-owner cannot update the whitelist
+    let info = mock_info("not_owner");
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::AddAddress {
+                address: "alice".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert_eq!(err, ContractError::Owner(NotOwner {}));
+
+    // Add a new distributor by the owner
+    let info = mock_info("owner");
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::AddAddress {
+                address: "alice".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    // Check if alice was added
+    let cfg: ConfigResponse = helpers::query(deps.as_ref(), QueryMsg::Config {});
+    assert_eq!(cfg.whitelisted_distributors.len(), 2);
+    assert!(cfg.whitelisted_distributors.contains(&"owner".to_string()));
+    assert!(cfg.whitelisted_distributors.contains(&"alice".to_string()));
+
+    // Add another distributor
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::AddAddress {
+                address: "bob".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    // Check if bob was added
+    let cfg: ConfigResponse = helpers::query(deps.as_ref(), QueryMsg::Config {});
+    assert_eq!(cfg.whitelisted_distributors.len(), 3);
+    assert!(cfg.whitelisted_distributors.contains(&"bob".to_string()));
+
+    // Remove a distributor
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::RemoveAddress {
+                address: "alice".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // Check if alice was removed
+    let cfg: ConfigResponse = helpers::query(deps.as_ref(), QueryMsg::Config {});
+    assert_eq!(cfg.whitelisted_distributors.len(), 2);
+    assert!(cfg.whitelisted_distributors.contains(&"owner".to_string()));
+    assert!(cfg.whitelisted_distributors.contains(&"bob".to_string()));
+    assert!(!cfg.whitelisted_distributors.contains(&"alice".to_string()));
+}
+
+#[test]
+fn only_whitelisted_can_distribute_rewards() {
+    let mut deps = helpers::setup_test();
+
+    // Add a new distributor "alice" to the whitelist
+    let info = mock_info("owner");
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::AddAddress {
+                address: "alice".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // Set up a balance of tokens
+    deps.querier.set_contract_balances(&[cosmwasm_std::coin(1000, "umars")]);
+
+    // Owner can distribute rewards
+    let info = mock_info("owner");
+    let msg = ExecuteMsg::DistributeRewards {
+        denom: "umars".to_string(),
+    };
+    let result: ContractResult<_> = execute(deps.as_mut(), mock_env(), info, msg);
+    assert!(result.is_ok());
+
+    // Alice can distribute rewards because she's whitelisted
+    let info = mock_info("alice");
+    let msg = ExecuteMsg::DistributeRewards {
+        denom: "umars".to_string(),
+    };
+    let result: ContractResult<_> = execute(deps.as_mut(), mock_env(), info, msg);
+    assert!(result.is_ok());
+
+    // Bob cannot distribute rewards because he's not whitelisted
+    let info = mock_info("bob");
+    let msg = ExecuteMsg::DistributeRewards {
+        denom: "umars".to_string(),
+    };
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::UnauthorizedDistributor { sender: _ }
+    ));
+    if let ContractError::UnauthorizedDistributor { sender } = err {
+        assert_eq!(sender, "bob");
+    }
+
+    // Remove all distributors except owner
+    let info = mock_info("owner");
+    let msg = ExecuteMsg::UpdateConfig {
+        new_cfg: UpdateConfig {
+            whitelist_actions: Some(vec![WhitelistAction::RemoveAddress {
+                address: "alice".to_string(),
+            }]),
+            ..Default::default()
+        },
+    };
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // Alice can no longer distribute rewards
+    let info = mock_info("alice");
+    let msg = ExecuteMsg::DistributeRewards {
+        denom: "umars".to_string(),
+    };
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::UnauthorizedDistributor { sender: _ }
+    ));
+}

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -1295,6 +1295,7 @@ fn setup_redbank(wasm: &Wasm<OsmosisTestApp>, signer: &SigningAccount) -> (Strin
             channel_id: "channel-1".to_string(),
             timeout_seconds: 60,
             slippage_tolerance: Decimal::new(Uint128::from(1u128)),
+            whitelisted_distributors: vec![signer.address()],
         },
     );
 

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -1294,7 +1294,6 @@ fn setup_redbank(wasm: &Wasm<OsmosisTestApp>, signer: &SigningAccount) -> (Strin
             },
             channel_id: "channel-1".to_string(),
             timeout_seconds: 60,
-            slippage_tolerance: Decimal::new(Uint128::from(1u128)),
             whitelisted_distributors: vec![signer.address()],
         },
     );

--- a/integration-tests/tests/test_rewards_collector.rs
+++ b/integration-tests/tests/test_rewards_collector.rs
@@ -510,7 +510,6 @@ fn distribute_rewards_if_ibc_channel_invalid() {
                 fee_collector_config: None,
                 channel_id: Some("channel-1".to_string()),
                 timeout_seconds: None,
-                slippage_tolerance: None,
             },
         },
         &[],

--- a/integration-tests/tests/test_rewards_collector.rs
+++ b/integration-tests/tests/test_rewards_collector.rs
@@ -87,6 +87,7 @@ fn swapping_rewards() {
             channel_id: "channel-1".to_string(),
             timeout_seconds: 60,
             slippage_tolerance: Decimal::percent(5),
+            whitelisted_distributors: vec![signer.address()],
         },
     );
 
@@ -470,6 +471,7 @@ fn distribute_rewards_if_ibc_channel_invalid() {
             channel_id: "".to_string(),
             timeout_seconds: 60,
             slippage_tolerance: Decimal::percent(1),
+            whitelisted_distributors: vec![signer.address()],
         },
     );
 
@@ -510,6 +512,7 @@ fn distribute_rewards_if_ibc_channel_invalid() {
                 fee_collector_config: None,
                 channel_id: Some("channel-1".to_string()),
                 timeout_seconds: None,
+                whitelist_actions: None,
             },
         },
         &[],

--- a/integration-tests/tests/test_rewards_collector.rs
+++ b/integration-tests/tests/test_rewards_collector.rs
@@ -86,7 +86,6 @@ fn swapping_rewards() {
             },
             channel_id: "channel-1".to_string(),
             timeout_seconds: 60,
-            slippage_tolerance: Decimal::percent(5),
             whitelisted_distributors: vec![signer.address()],
         },
     );
@@ -470,7 +469,6 @@ fn distribute_rewards_if_ibc_channel_invalid() {
             },
             channel_id: "".to_string(),
             timeout_seconds: 60,
-            slippage_tolerance: Decimal::percent(1),
             whitelisted_distributors: vec![signer.address()],
         },
     );

--- a/packages/testing/src/integration/mock_env.rs
+++ b/packages/testing/src/integration/mock_env.rs
@@ -1098,6 +1098,7 @@ impl MockEnvBuilder {
                     fee_collector_config: self.fee_collector_config.clone(),
                     channel_id: "0".to_string(),
                     timeout_seconds: 900,
+                    whitelisted_distributors: vec![],
                     slippage_tolerance: self.slippage_tolerance,
                 },
                 &[],

--- a/packages/testing/src/integration/mock_env.rs
+++ b/packages/testing/src/integration/mock_env.rs
@@ -836,7 +836,6 @@ pub struct MockEnvBuilder {
     safety_fund_config: RewardConfig,
     revenue_share_config: RewardConfig,
     fee_collector_config: RewardConfig,
-    slippage_tolerance: Decimal,
 
     pyth_contract_addr: String,
 
@@ -875,7 +874,6 @@ impl MockEnvBuilder {
                 target_denom: "umars".to_string(),
                 transfer_type: rewards_collector::TransferType::Ibc,
             },
-            slippage_tolerance: Decimal::percent(5),
             pyth_contract_addr: "osmo1svg55quy7jjee6dn0qx85qxxvx5cafkkw4tmqpcjr9dx99l0zrhs4usft5"
                 .to_string(), // correct bech32 addr to pass validation
             credit_manager_contract_addr:
@@ -920,11 +918,6 @@ impl MockEnvBuilder {
 
     pub fn fee_collector_config(&mut self, config: RewardConfig) -> &mut Self {
         self.fee_collector_config = config;
-        self
-    }
-
-    pub fn slippage_tolerance(&mut self, percentage: Decimal) -> &mut Self {
-        self.slippage_tolerance = percentage;
         self
     }
 
@@ -1099,7 +1092,6 @@ impl MockEnvBuilder {
                     channel_id: "0".to_string(),
                     timeout_seconds: 900,
                     whitelisted_distributors: vec![],
-                    slippage_tolerance: self.slippage_tolerance,
                 },
                 &[],
                 "rewards-collector",

--- a/packages/testing/src/multitest/helpers/mock_env.rs
+++ b/packages/testing/src/multitest/helpers/mock_env.rs
@@ -1766,7 +1766,6 @@ impl MockEnvBuilder {
                     channel_id: "".to_string(),
                     timeout_seconds: 1,
                     whitelisted_distributors: vec![],
-                    slippage_tolerance: Default::default(),
                 },
                 &[],
                 "mock-rewards-collector",

--- a/packages/testing/src/multitest/helpers/mock_env.rs
+++ b/packages/testing/src/multitest/helpers/mock_env.rs
@@ -1765,6 +1765,7 @@ impl MockEnvBuilder {
                     },
                     channel_id: "".to_string(),
                     timeout_seconds: 1,
+                    whitelisted_distributors: vec![],
                     slippage_tolerance: Default::default(),
                 },
                 &[],

--- a/packages/types/src/rewards_collector.rs
+++ b/packages/types/src/rewards_collector.rs
@@ -10,8 +10,6 @@ use mars_utils::{
 
 use crate::{credit_manager::Action, incentives::IncentiveKind, swapper::SwapperRoute};
 
-const MAX_SLIPPAGE_TOLERANCE_PERCENTAGE: u64 = 50;
-
 #[cw_serde]
 pub struct InstantiateMsg {
     /// The contract's owner
@@ -78,8 +76,6 @@ pub struct Config {
     pub channel_id: String,
     /// Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received
     pub timeout_seconds: u64,
-    /// Maximum percentage of price movement (minimum amount you accept to receive during swap)
-    pub slippage_tolerance: Decimal,
 }
 
 impl Config {
@@ -88,14 +84,6 @@ impl Config {
         decimal_param_le_one(total_tax_rate, "total_tax_rate")?;
 
         integer_param_gt_zero(self.timeout_seconds, "timeout_seconds")?;
-
-        if self.slippage_tolerance > Decimal::percent(MAX_SLIPPAGE_TOLERANCE_PERCENTAGE) {
-            return Err(ValidationError::InvalidParam {
-                param_name: "slippage_tolerance".to_string(),
-                invalid_value: self.slippage_tolerance.to_string(),
-                predicate: format!("<= {}", Decimal::percent(MAX_SLIPPAGE_TOLERANCE_PERCENTAGE)),
-            });
-        }
 
         // There is an assumption that revenue share and safety fund are swapped to the same denom
         assert_eq!(self.safety_fund_config.target_denom, self.revenue_share_config.target_denom);
@@ -122,7 +110,6 @@ impl Config {
             fee_collector_config: msg.fee_collector_config,
             channel_id: msg.channel_id,
             timeout_seconds: msg.timeout_seconds,
-            slippage_tolerance: msg.slippage_tolerance,
         })
     }
 }
@@ -146,8 +133,6 @@ pub struct UpdateConfig {
     pub channel_id: Option<String>,
     /// Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received
     pub timeout_seconds: Option<u64>,
-    /// Maximum percentage of price movement (minimum amount you accept to receive during swap)
-    pub slippage_tolerance: Option<Decimal>,
 }
 
 #[cw_serde]
@@ -229,8 +214,6 @@ pub struct ConfigResponse {
     pub channel_id: String,
     /// Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received
     pub timeout_seconds: u64,
-    /// Maximum percentage of price movement (minimum amount you accept to receive during swap)
-    pub slippage_tolerance: Decimal,
 }
 
 #[cw_serde]

--- a/packages/types/src/rewards_collector.rs
+++ b/packages/types/src/rewards_collector.rs
@@ -30,8 +30,6 @@ pub struct InstantiateMsg {
     pub channel_id: String,
     /// Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received
     pub timeout_seconds: u64,
-    /// Maximum percentage of price movement (minimum amount you accept to receive during swap)
-    pub slippage_tolerance: Decimal,
     /// List of addresses that are allowed to execute the rewards distribution
     pub whitelisted_distributors: Vec<String>,
 }

--- a/packages/types/src/rewards_collector.rs
+++ b/packages/types/src/rewards_collector.rs
@@ -129,9 +129,13 @@ impl Config {
 #[cw_serde]
 pub enum WhitelistAction {
     /// Add an address to the whitelist of distributors
-    AddAddress { address: String },
+    AddAddress {
+        address: String,
+    },
     /// Remove an address from the whitelist of distributors
-    RemoveAddress { address: String },
+    RemoveAddress {
+        address: String,
+    },
 }
 
 #[cw_serde]

--- a/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
+++ b/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
@@ -15,8 +15,8 @@
       "revenue_share_tax_rate",
       "safety_fund_config",
       "safety_tax_rate",
-      "slippage_tolerance",
-      "timeout_seconds"
+      "timeout_seconds",
+      "whitelisted_distributors"
     ],
     "properties": {
       "address_provider": {
@@ -71,19 +71,18 @@
           }
         ]
       },
-      "slippage_tolerance": {
-        "description": "Maximum percentage of price movement (minimum amount you accept to receive during swap)",
-        "allOf": [
-          {
-            "$ref": "#/definitions/Decimal"
-          }
-        ]
-      },
       "timeout_seconds": {
         "description": "Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received",
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
+      },
+      "whitelisted_distributors": {
+        "description": "List of addresses that are allowed to execute the rewards distribution",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "additionalProperties": false,
@@ -1626,17 +1625,6 @@
               }
             ]
           },
-          "slippage_tolerance": {
-            "description": "Maximum percentage of price movement (minimum amount you accept to receive during swap)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Decimal"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "timeout_seconds": {
             "description": "Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received",
             "type": [
@@ -1645,6 +1633,16 @@
             ],
             "format": "uint64",
             "minimum": 0.0
+          },
+          "whitelist_actions": {
+            "description": "Actions to modify the whitelist of distributors",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/WhitelistAction"
+            }
           }
         },
         "additionalProperties": false
@@ -1667,6 +1665,54 @@
           "u_n_l_o_c_k_e_d",
           "l_o_c_k_e_d",
           "u_n_l_o_c_k_i_n_g"
+        ]
+      },
+      "WhitelistAction": {
+        "oneOf": [
+          {
+            "description": "Add an address to the whitelist of distributors",
+            "type": "object",
+            "required": [
+              "add_address"
+            ],
+            "properties": {
+              "add_address": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Remove an address from the whitelist of distributors",
+            "type": "object",
+            "required": [
+              "remove_address"
+            ],
+            "properties": {
+              "remove_address": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       }
     }
@@ -1706,8 +1752,8 @@
         "revenue_share_tax_rate",
         "safety_fund_config",
         "safety_tax_rate",
-        "slippage_tolerance",
-        "timeout_seconds"
+        "timeout_seconds",
+        "whitelisted_distributors"
       ],
       "properties": {
         "address_provider": {
@@ -1772,19 +1818,18 @@
             }
           ]
         },
-        "slippage_tolerance": {
-          "description": "Maximum percentage of price movement (minimum amount you accept to receive during swap)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Decimal"
-            }
-          ]
-        },
         "timeout_seconds": {
           "description": "Number of seconds after which an IBC transfer is to be considered failed, if no acknowledgement is received",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "whitelisted_distributors": {
+          "description": "List of addresses that are allowed to execute the rewards distribution",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,

--- a/scripts/deploy/base/deployer.ts
+++ b/scripts/deploy/base/deployer.ts
@@ -416,7 +416,7 @@ export class Deployer {
       fee_collector_config: this.config.rewardsCollector.feeCollectorConfig,
       channel_id: this.config.rewardsCollector.channelId,
       timeout_seconds: this.config.rewardsCollector.timeoutSeconds,
-      slippage_tolerance: this.config.rewardsCollector.slippageTolerance,
+      whitelisted_distributors: this.config.rewardsCollector.whitelistedDistributors,
     }
     await this.instantiate('rewardsCollector', this.storage.codeIds['rewardsCollector']!, msg)
   }

--- a/scripts/deploy/neutron/devnet-config.ts
+++ b/scripts/deploy/neutron/devnet-config.ts
@@ -464,7 +464,7 @@ export const neutronDevnetConfig: DeploymentConfig = {
       target_denom: marsDenom,
       transfer_type: 'ibc',
     },
-    slippageTolerance: '0.01',
+    whitelistedDistributors: [],
   },
   incentives: {
     epochDuration: 604800, // 1 week

--- a/scripts/deploy/neutron/mainnet-config.ts
+++ b/scripts/deploy/neutron/mainnet-config.ts
@@ -390,7 +390,7 @@ export const neutronMainnetConfig: DeploymentConfig = {
       target_denom: marsDenom,
       transfer_type: 'ibc',
     },
-    slippageTolerance: '0.01',
+    whitelistedDistributors: []
   },
   incentives: {
     epochDuration: 604800, // 1 week

--- a/scripts/deploy/neutron/mainnet-config.ts
+++ b/scripts/deploy/neutron/mainnet-config.ts
@@ -390,7 +390,7 @@ export const neutronMainnetConfig: DeploymentConfig = {
       target_denom: marsDenom,
       transfer_type: 'ibc',
     },
-    whitelistedDistributors: []
+    whitelistedDistributors: [],
   },
   incentives: {
     epochDuration: 604800, // 1 week

--- a/scripts/deploy/neutron/testnet-config.ts
+++ b/scripts/deploy/neutron/testnet-config.ts
@@ -753,7 +753,7 @@ export const neutronTestnetConfig: DeploymentConfig = {
       target_denom: marsDenom,
       transfer_type: 'ibc',
     },
-    slippageTolerance: '0.01',
+    whitelistedDistributors: [],
   },
   incentives: {
     epochDuration: 604800, // 1 week

--- a/scripts/deploy/osmosis/mainnet-config.ts
+++ b/scripts/deploy/osmosis/mainnet-config.ts
@@ -1068,7 +1068,7 @@ export const osmosisMainnetConfig: DeploymentConfig = {
       target_denom: axlUSDC,
       transfer_type: 'ibc',
     },
-    slippageTolerance: '0.01',
+    whitelistedDistributors: [],
   },
   incentives: {
     epochDuration: 604800, // 1 week

--- a/scripts/deploy/osmosis/testnet-config.ts
+++ b/scripts/deploy/osmosis/testnet-config.ts
@@ -278,7 +278,7 @@ export const osmosisTestnetConfig: DeploymentConfig = {
       target_denom: aUSDC,
       transfer_type: 'bank',
     },
-    slippageTolerance: '0.01',
+    whitelistedDistributors: [],
   },
   keeperFeeConfig: {
     min_fee: { amount: '1000000', denom: aUSDC },

--- a/scripts/types/config.ts
+++ b/scripts/types/config.ts
@@ -69,7 +69,7 @@ export interface DeploymentConfig {
     revenueShareConfig: RewardConfig
     safetyFundConfig: RewardConfig
     feeCollectorConfig: RewardConfig
-    slippageTolerance: string
+    whitelistedDistributors: string[]
   }
   incentives: {
     epochDuration: number

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.client.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.client.ts
@@ -14,6 +14,7 @@ import {
   RewardConfig,
   ExecuteMsg,
   OwnerUpdate,
+  WhitelistAction,
   Uint128,
   Action,
   ActionAmount,

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.react-query.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.react-query.ts
@@ -15,6 +15,7 @@ import {
   RewardConfig,
   ExecuteMsg,
   OwnerUpdate,
+  WhitelistAction,
   Uint128,
   Action,
   ActionAmount,

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
@@ -16,8 +16,8 @@ export interface InstantiateMsg {
   revenue_share_tax_rate: Decimal
   safety_fund_config: RewardConfig
   safety_tax_rate: Decimal
-  slippage_tolerance: Decimal
   timeout_seconds: number
+  whitelisted_distributors: string[]
 }
 export interface RewardConfig {
   target_denom: string
@@ -82,6 +82,17 @@ export type OwnerUpdate =
       }
     }
   | 'clear_emergency_owner'
+export type WhitelistAction =
+  | {
+      add_address: {
+        address: string
+      }
+    }
+  | {
+      remove_address: {
+        address: string
+      }
+    }
 export type Uint128 = string
 export type Action =
   | {
@@ -295,8 +306,8 @@ export interface UpdateConfig {
   revenue_share_tax_rate?: Decimal | null
   safety_fund_config?: RewardConfig | null
   safety_tax_rate?: Decimal | null
-  slippage_tolerance?: Decimal | null
   timeout_seconds?: number | null
+  whitelist_actions?: WhitelistAction[] | null
 }
 export interface Coin {
   amount: Uint128
@@ -337,6 +348,6 @@ export interface ConfigResponse {
   revenue_share_tax_rate: Decimal
   safety_fund_config: RewardConfig
   safety_tax_rate: Decimal
-  slippage_tolerance: Decimal
   timeout_seconds: number
+  whitelisted_distributors: string[]
 }


### PR DESCRIPTION
The slippage check is difficult to enforce due to poor oracle pricing of mars.

Therefore, this PR will solve this by removing the slippage check.

However, if we remove the slippage check we open ourselves up to potential exploits / extraction of rewards, so to prevent this I have added a whitelist for distributors. Distributing bots will need to be added to the distributors whitelist by the owner of the given rewards collector contract.