### PR TITLE
Add spot swap fee query

### DIFF
--- a/contracts/account-nft/tests/tests/helpers/mock_env_builder.rs
+++ b/contracts/account-nft/tests/tests/helpers/mock_env_builder.rs
@@ -161,7 +161,6 @@ impl MockEnvBuilder {
                         perps: "n/a".to_string(),
                         keeper_fee_config: Default::default(),
                         perps_liquidation_bonus_ratio: Decimal::percent(60),
-                        swap_fee: Decimal::percent(1),
                     },
                 },
                 &[],

--- a/contracts/credit-manager/src/contract.rs
+++ b/contracts/credit-manager/src/contract.rs
@@ -18,8 +18,9 @@ use crate::{
         query_accounts, query_all_coin_balances, query_all_debt_shares,
         query_all_total_debt_shares, query_all_trigger_orders,
         query_all_trigger_orders_for_account, query_all_vault_positions,
-        query_all_vault_utilizations, query_config, query_positions, query_total_debt_shares,
-        query_vault_bindings, query_vault_position_value, query_vault_utilization,
+        query_all_vault_utilizations, query_config, query_positions, query_swap_fee,
+        query_total_debt_shares, query_vault_bindings, query_vault_position_value,
+        query_vault_utilization,
     },
     repay::repay_from_wallet,
     state::NEXT_TRIGGER_ID,
@@ -172,6 +173,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             start_after,
             limit,
         } => to_json_binary(&query_vault_bindings(deps, start_after, limit)?),
+        QueryMsg::SwapFeeRate {} => to_json_binary(&query_swap_fee(deps)?),
     };
     res.map_err(Into::into)
 }

--- a/contracts/credit-manager/src/query.rs
+++ b/contracts/credit-manager/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Deps, Env, Order, StdResult};
+use cosmwasm_std::{Coin, Decimal, Deps, Env, Order, StdResult};
 use cw_paginate::{
     paginate_map, paginate_map_query, paginate_prefix_query, PaginationResponse, DEFAULT_LIMIT,
     MAX_LIMIT,
@@ -67,8 +67,11 @@ pub fn query_config(deps: Deps) -> ContractResult<ConfigResponse> {
         rewards_collector: REWARDS_COLLECTOR.may_load(deps.storage)?,
         keeper_fee_config: KEEPER_FEE_CONFIG.load(deps.storage)?,
         perps_liquidation_bonus_ratio: PERPS_LB_RATIO.load(deps.storage)?,
-        swap_fee: SWAP_FEE.load(deps.storage)?,
     })
+}
+
+pub fn query_swap_fee(deps: Deps) -> ContractResult<Decimal> {
+    Ok(SWAP_FEE.load(deps.storage)?)
 }
 
 pub fn query_positions(

--- a/contracts/credit-manager/tests/tests/test_update_config.rs
+++ b/contracts/credit-manager/tests/tests/test_update_config.rs
@@ -178,9 +178,6 @@ fn update_config_works_with_full_config() {
     assert_eq!(new_config.keeper_fee_config, keeper_fee_config);
     assert_ne!(new_config.keeper_fee_config, original_config.keeper_fee_config);
 
-    assert_eq!(new_config.swap_fee, new_swap_fee);
-    assert_ne!(new_config.swap_fee, original_config.swap_fee);
-
     let rc_accounts = mock.query_accounts(&new_rewards_collector, None, None);
     let rc_account = rc_accounts.first().unwrap();
     assert_eq!(rc_account.kind, AccountKind::Default);

--- a/contracts/health/tests/tests/helpers/mock_env_builder.rs
+++ b/contracts/health/tests/tests/helpers/mock_env_builder.rs
@@ -188,7 +188,6 @@ impl MockEnvBuilder {
                         perps: "n/a".to_string(),
                         keeper_fee_config: Default::default(),
                         perps_liquidation_bonus_ratio: Decimal::percent(60),
-                        swap_fee: Decimal::permille(1),
                     },
                 },
                 &[],

--- a/packages/types/src/credit_manager/query.rs
+++ b/packages/types/src/credit_manager/query.rs
@@ -114,6 +114,8 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    #[returns(Decimal)]
+    SwapFeeRate {},
 }
 
 #[cw_serde]
@@ -229,7 +231,6 @@ pub struct ConfigResponse {
     pub rewards_collector: Option<RewardsCollector>,
     pub keeper_fee_config: KeeperFeeConfig,
     pub perps_liquidation_bonus_ratio: Decimal,
-    pub swap_fee: Decimal,
 }
 
 #[cw_serde]

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -3743,6 +3743,19 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "swap_fee_rate"
+        ],
+        "properties": {
+          "swap_fee_rate": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
@@ -6769,7 +6782,6 @@
         "perps",
         "perps_liquidation_bonus_ratio",
         "red_bank",
-        "swap_fee",
         "swapper",
         "zapper"
       ],
@@ -6822,9 +6834,6 @@
               "type": "null"
             }
           ]
-        },
-        "swap_fee": {
-          "$ref": "#/definitions/Decimal"
         },
         "swapper": {
           "type": "string"
@@ -7298,6 +7307,12 @@
           "additionalProperties": false
         }
       }
+    },
+    "swap_fee_rate": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Decimal",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
     },
     "total_debt_shares": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
@@ -187,6 +187,7 @@ export interface MarsCreditManagerReadOnlyInterface {
     limit?: number
     startAfter?: string
   }) => Promise<ArrayOfVaultBinding>
+  swapFeeRate: () => Promise<Decimal>
 }
 export class MarsCreditManagerQueryClient implements MarsCreditManagerReadOnlyInterface {
   client: CosmWasmClient
@@ -211,6 +212,7 @@ export class MarsCreditManagerQueryClient implements MarsCreditManagerReadOnlyIn
     this.allTriggerOrders = this.allTriggerOrders.bind(this)
     this.allAccountTriggerOrders = this.allAccountTriggerOrders.bind(this)
     this.vaultBindings = this.vaultBindings.bind(this)
+    this.swapFeeRate = this.swapFeeRate.bind(this)
   }
   accountKind = async ({ accountId }: { accountId: string }): Promise<AccountKind> => {
     return this.client.queryContractSmart(this.contractAddress, {
@@ -416,6 +418,11 @@ export class MarsCreditManagerQueryClient implements MarsCreditManagerReadOnlyIn
         limit,
         start_after: startAfter,
       },
+    })
+  }
+  swapFeeRate = async (): Promise<Decimal> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      swap_fee_rate: {},
     })
   }
 }

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
@@ -248,6 +248,14 @@ export const marsCreditManagerQueryKeys = {
         args,
       },
     ] as const,
+  swapFeeRate: (contractAddress: string | undefined, args?: Record<string, unknown>) =>
+    [
+      {
+        ...marsCreditManagerQueryKeys.address(contractAddress)[0],
+        method: 'swap_fee_rate',
+        args,
+      },
+    ] as const,
 }
 export interface MarsCreditManagerReactQuery<TResponse, TData = TResponse> {
   client: MarsCreditManagerQueryClient | undefined
@@ -257,6 +265,21 @@ export interface MarsCreditManagerReactQuery<TResponse, TData = TResponse> {
   > & {
     initialData?: undefined
   }
+}
+export interface MarsCreditManagerSwapFeeRateQuery<TData>
+  extends MarsCreditManagerReactQuery<Decimal, TData> {}
+export function useMarsCreditManagerSwapFeeRateQuery<TData = Decimal>({
+  client,
+  options,
+}: MarsCreditManagerSwapFeeRateQuery<TData>) {
+  return useQuery<Decimal, Error, TData>(
+    marsCreditManagerQueryKeys.swapFeeRate(client?.contractAddress),
+    () => (client ? client.swapFeeRate() : Promise.reject(new Error('Invalid client'))),
+    {
+      ...options,
+      enabled: !!client && (options?.enabled != undefined ? options.enabled : true),
+    },
+  )
 }
 export interface MarsCreditManagerVaultBindingsQuery<TData>
   extends MarsCreditManagerReactQuery<ArrayOfVaultBinding, TData> {

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -751,6 +751,9 @@ export type QueryMsg =
         start_after?: string | null
       }
     }
+  | {
+      swap_fee_rate: {}
+    }
 export type ActionKind = 'default' | 'liquidation'
 export type VaultPositionAmount =
   | {
@@ -840,7 +843,6 @@ export interface ConfigResponse {
   perps_liquidation_bonus_ratio: Decimal
   red_bank: string
   rewards_collector?: RewardsCollector | null
-  swap_fee: Decimal
   swapper: string
   zapper: string
 }


### PR DESCRIPTION
We need to remove the spot fee from the config response added in #33 because this will break the existing (unmigratable) vaults